### PR TITLE
Update reference to `auth/jwt_proxy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - Setup the [jwt-proxy development environment](https://github.com/grafana/grafana/tree/main/devenv/docker/blocks/jwt_proxy)
 
-`make devenv sources="jwt_proxy"`
+`make devenv sources="auth/jwt_proxy"`
 
 Add the following to your grafana configuration.
 


### PR DESCRIPTION
** Why do we need this? **

All devenv docker blocks have been grouped under `auth/`. The reference in this README needs to reflect that.